### PR TITLE
[BE] Convert tags & feed endpoints to 'POST' type

### DIFF
--- a/backend/transport/server.go
+++ b/backend/transport/server.go
@@ -35,11 +35,11 @@ func (s *Server) Run(port string) error {
 
 	trendingTags := TrendingTagsHandler(db)
 	trendingTags = securedMiddleware(trendingTags)
-	router.HandleFunc("GET /v1/trending-tags", handlers.NewHttpHandler(trendingTags))
+	router.HandleFunc("POST /v1/trending-tags", handlers.NewHttpHandler(trendingTags))
 
 	trendingFeed := TrendingFeedHandler(db)
 	trendingFeed = securedMiddleware(trendingFeed)
-	router.HandleFunc("GET /v1/trending-feed", handlers.NewHttpHandler(trendingFeed))
+	router.HandleFunc("POST /v1/trending-feed", handlers.NewHttpHandler(trendingFeed))
 
 	guestSignUp := GuestSignUpHandler(db)
 	guestSignUp = securedMiddleware(guestSignUp)


### PR DESCRIPTION
### Brief Description

http POST APIs are generally more secure (no parameters are leaked from the url) & more extensible. Converting tags & feed endpoints to POST method