### PR TITLE
[BE] Serve HTTPS if cert path environment variables are configured

### DIFF
--- a/backend/transport/server.go
+++ b/backend/transport/server.go
@@ -72,7 +72,7 @@ func (s *Server) Run(port int) error {
 	log.Println("snakechat server started listening on " + listenAddr)
 	if tlsConfig != nil {
 		server := &http.Server{
-			Addr: listenAddr,
+			Addr: ":443",
 			TLSConfig: &tls.Config{
 				MinVersion:       tls.VersionTLS12,
 				CurvePreferences: []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},


### PR DESCRIPTION
Added support to serve HTTPS traffic if TLS certifcate environment variables are configured
`SSL_CERT_FILE` : Full chain key path
`SSL_KEY_FILE`: Private key path