### PR TITLE
[BE] Enable ssl by CLI argument

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -9,10 +9,11 @@ func main() {
 	portUsage := "port to listen on"
 	defaultPort := 8080
 	port := flag.Int("port", defaultPort, portUsage)
+	enableSsl := flag.Bool("ssl", false, "enable SSL")
 	flag.IntVar(port, "p", defaultPort, portUsage)
 	flag.Parse()
 	server := transport.NewServer()
-	err := server.Run(*port)
+	err := server.Run(*port, *enableSsl)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
To support offline debugging, we might want to run the server in http mode while ssl related environment variables are set. Thus added a CLI flag `--ssl` to serve the traffic in https. This flag will be `false` by default and will keep on serving the traffic with http